### PR TITLE
perf(readDirectory): Count only git-indexed files instead of all files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "koji-tools",
-  "version": "0.1.0",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    "ansi-colors-and-styles": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors-and-styles/-/ansi-colors-and-styles-1.0.3.tgz",
+      "integrity": "sha512-Nh79L9mUpz/rxKJna9hTdyuJZaDF7s0cGbWc7hDJJ6c7YSGEcV1ak/fHDXw+9V+u5qeHeITeeLgX7Pwl5vRz6g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
   },
   "homepage": "https://gokoji.com",
   "dependencies": {
+    "ansi-colors-and-styles": "^1.0.3"
   },
-  "browser": { "fs": false, "path": false, "os": false}
+  "browser": {
+    "fs": false,
+    "path": false,
+    "os": false
+  }
 }

--- a/tools/findRootDirectory.js
+++ b/tools/findRootDirectory.js
@@ -1,18 +1,23 @@
-var fs = require('fs');
+const fs = require('fs')
+const path = require('path')
 
 module.exports = () => {
     // puts us in the directory where this is a node module of.
-    let path = `${__dirname}/../../..`;
-
+    let dirPath = process.cwd()
+    
     // keep walking down the street.
     try {
-        while(!fs.readdirSync(path).includes('.koji')) {
-            path += '/..';
+        while (!fs.readdirSync(dirPath).includes('.koji')) {
+            const parentPath = path.dirname(dirPath)
+            if (dirPath === parentPath) // noinspection ExceptionCaughtLocallyJS
+                throw Error(`Couldn't find ".koji" folder.`)
+            dirPath = parentPath
         }
-    } catch(err) {
+    } catch (err) {
         // give up and do a standard config
-        path = `${__dirname}/../../../..`
+        dirPath = process.cwd()
+        console.log(`Couldn't find ".koji" folder. Default path was used: "${dirPath}"`)
     }
-
-    return path;
+    
+    return dirPath
 }

--- a/tools/readDirectory.js
+++ b/tools/readDirectory.js
@@ -1,21 +1,18 @@
-const fs = require('fs');
+const {execSync} = require('child_process')
+const {_YLW, RED, RST} = require('ansi-colors-and-styles')
+const path = require('path')
 
-// Recurse through all directories to find koji dotfiles
-module.exports = (directory) => readDirectory(directory);
-
-
-function readDirectory(directory) {
-  let results = [];
-  fs
-    .readdirSync(directory)
-    .forEach((fileName) => {
-      const file = `${directory}/${fileName}`;
-      const stat = fs.statSync(file);
-      if (stat && stat.isDirectory()) {
-        results = results.concat(readDirectory(file));
-      } else {
-        results.push(file);
-      }
-    });
-  return results;
+// Get all git-indexed paths to find koji files
+module.exports = directory => {
+   try {
+      return execSync('git ls-files', {cwd: directory}).toString()
+            .replace(/\n$/, '')
+            .split('\n')
+            .map(relativePath => path.resolve(directory, relativePath))
+   } catch (error) {
+      throw Error(error.message +
+            `${_YLW}${RED}Have you installed "git" and added it to the "PATH"? If no see: ` +
+            `https://git-scm.com/book/en/v2/Getting-Started-Installing-Git${RST}\n`
+      )
+   }
 }


### PR DESCRIPTION
Improving the performance through including only git-indexed files. As a result, some unnecessary
paths (".git" and all 'gitignored' paths like "node_modules" and IDE-related directories) will be
excluded. The difference is significant in large (and even medium) npm projects.

See: https://github.com/madewithkoji/koji-tools/issues/10