### PR TITLE
"fs.service" was added to manage file-system indexing more efficient + fix #21

### DIFF
--- a/src/tools/fs.service.js
+++ b/src/tools/fs.service.js
@@ -1,0 +1,20 @@
+import readDirectory from './readDirectory';
+import findRootDirectory from './findRootDirectory';
+
+// noinspection JSUnusedGlobalSymbols
+export default (() => {
+  let kojiConfigFiles;
+
+  function refresh() {
+    kojiConfigFiles = readDirectory(findRootDirectory())
+      .filter((path) => (path.endsWith('koji.json') || path.includes('.koji')) && !path.includes('.koji-resources'));
+  }
+
+  refresh();
+
+  // noinspection JSUnusedAssignment, JSUnusedGlobalSymbols
+  return {
+    kojiConfigFiles,
+    refresh,
+  };
+})();

--- a/src/tools/writeConfig.js
+++ b/src/tools/writeConfig.js
@@ -1,35 +1,31 @@
 import fs from 'fs';
-import readDirectory from './readDirectory';
-import findRootDirectory from './findRootDirectory';
+import fsService from './fs.service';
 
-const writeConfig = () => {
+export default function writeConfig() {
   const projectConfig = {};
-  const root = findRootDirectory();
 
   // Add config items from koji json files
-  readDirectory(root)
-    .filter((path) => (path.endsWith('koji.json') || path.includes('.koji')) && !path.includes('.koji-resources'))
-    .forEach((path) => {
-      try {
-        const file = JSON.parse(fs.readFileSync(path, 'utf8'));
+  fsService.kojiConfigFiles.forEach((path) => {
+    try {
+      const file = JSON.parse(fs.readFileSync(path, 'utf8'));
 
-        Object.keys(file).forEach((key) => {
-          // If the key already exists in the project config, use it
-          if (projectConfig[key]) {
-            if (Array.isArray(projectConfig[key]) && Array.isArray(file[key])) {
-              projectConfig[key] = projectConfig[key].concat(file[key]);
-            } else {
-              projectConfig[key] = Object.assign(projectConfig[key], file[key]);
-            }
+      Object.keys(file).forEach((key) => {
+        // If the key already exists in the project config, use it
+        if (projectConfig[key]) {
+          if (Array.isArray(projectConfig[key]) && Array.isArray(file[key])) {
+            projectConfig[key] = projectConfig[key].concat(file[key]);
           } else {
-            // Otherwise, set it
-            projectConfig[key] = file[key];
+            projectConfig[key] = Object.assign(projectConfig[key], file[key]);
           }
-        });
-      } catch (err) {
-        //
-      }
-    });
+        } else {
+          // Otherwise, set it
+          projectConfig[key] = file[key];
+        }
+      });
+    } catch (err) {
+      //
+    }
+  });
 
   // Expose the serviceMap based on environment variables
   projectConfig.serviceMap = Object.keys(process.env).reduce((acc, cur) => {
@@ -48,6 +44,4 @@ const writeConfig = () => {
   } catch (err) {
     //
   }
-};
-
-export default writeConfig;
+}

--- a/src/watch.js
+++ b/src/watch.js
@@ -1,16 +1,14 @@
-import chokidar from 'chokidar';
-
-import readDirectory from './tools/readDirectory';
-import findRootDirectory from './tools/findRootDirectory';
-
+import * as chokidar from 'chokidar';
+import fsService from './tools/fs.service';
 import writeConfig from './tools/writeConfig';
 
-const watch = () => {
+// noinspection JSUnusedGlobalSymbols
+export default function watch() {
   // Generate a base config
   writeConfig();
 
   // Watch the .koji directory from a node_modules directory
-  const files = readDirectory(findRootDirectory())
+  const files = fsService.kojiConfigFiles
     .filter((path) => (path.endsWith('koji.json') || path.includes('.koji')) && !path.includes('.koji-resources'));
 
   // Note: Polling is used by default in the container via
@@ -26,6 +24,4 @@ const watch = () => {
       const watched = watcher.getWatched();
       Object.keys(watched).map((path) => watched[path].map((file) => console.log(`[@withkoji/vcc] Watching ${path}/${file}`)));
     });
-};
-
-export default watch;
+}


### PR DESCRIPTION
`fs.service` was added to manage file-system indexing more efficient. It also fixes
"twice-event-report" problem caused by `git` command (#21).
This service (that is a singleton) can cache the result of requests and so improves the performance.
It exposes an extra layer on top of `readDirectory` that consumers (`buildConfig.js`, `refresh.js`,
and `watch.js` for now) should use (instead of direct access to `readDirectory`).